### PR TITLE
Remove copilot and claude-code-ide

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -1,0 +1,9 @@
+;;; early-init.el --- Early initialization -*- lexical-binding: t; -*-
+;;; Commentary: Runs before init.el; defers package.el initialization to init.el
+
+;;; Code:
+
+;; init.el 内で明示的に package-initialize するため、起動時の自動初期化を抑制する
+(setq package-enable-at-startup nil)
+
+;;; early-init.el ends here

--- a/init.el
+++ b/init.el
@@ -4,29 +4,6 @@
 ;;; Code:
 
 ;; ============================================================
-;; straight.el bootstrap (copilot と prisma-mode のみ)
-;; ============================================================
-(defvar bootstrap-version)
-(let ((bootstrap-file
-       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
-      (bootstrap-version 6))
-  (unless (file-exists-p bootstrap-file)
-    (with-current-buffer
-        (url-retrieve-synchronously
-         "https://raw.githubusercontent.com/radian-software/straight.el/develop/install.el"
-         'silent 'inhibit-cookies)
-      (goto-char (point-max))
-      (eval-print-last-sexp)))
-  (load bootstrap-file nil 'nomessage))
-
-(straight-use-package
- '(copilot :type git :host github :repo "copilot-emacs/copilot.el"
-           :files ("dist" "*.el")))
-
-(straight-use-package
- '(claude-code-ide :type git :host github :repo "manzaltu/claude-code-ide.el"))
-
-;; ============================================================
 ;; package.el
 ;; ============================================================
 (require 'package)
@@ -279,19 +256,6 @@
   (global-git-gutter-mode t))
 
 ;; ============================================================
-;; GitHub Copilot (straight.el でインストール済み)
-;; ============================================================
-(use-package copilot
-  :ensure nil
-  :hook (prog-mode . copilot-mode)
-  :bind
-  (:map copilot-completion-map
-   ("C-p"   . copilot-previous-completion)
-   ("C-n"   . copilot-next-completion)
-   ("<tab>" . copilot-accept-completion)
-   ("TAB"   . copilot-accept-completion)))
-
-;; ============================================================
 ;; eglot (Emacs 29 組み込み LSP クライアント)
 ;; ============================================================
 (use-package eglot
@@ -417,25 +381,22 @@
 (unless (server-running-p)
   (server-start))
 
-;; eat: ターミナルエミュレータ（claude-code-ide のバックエンド）
+;; eat: ターミナルエミュレータ
 (use-package eat
   :ensure t)
 
-;; vterm: claude-code-ide のデフォルトターミナルバックエンド
+;; vterm: ターミナルエミュレータ
 (use-package vterm
   :ensure t
   :custom
+  ;; daemon 起動時にモジュールコンパイルの確認プロンプトでブロックしないようにする
+  (vterm-always-compile-module t)
   ;; C-h をグローバルで delete-backward-char にしているため、
   ;; vterm 内でもターミナルに送信されるよう exceptions から除外
   (vterm-keymap-exceptions '("C-c" "C-x" "C-u" "C-g" "C-l" "M-x" "M-o" "C-v" "M-v" "C-y" "M-y"))
   :config
   ;; exceptions だけでは反映されない場合があるため明示的にバインド
   (define-key vterm-mode-map (kbd "C-h") #'vterm--self-insert))
-
-;; claude-code-ide: Emacs 内で Claude Code を起動（straight.el でインストール済み）
-(use-package claude-code-ide
-  :ensure nil
-  :bind ("C-c C-c" . claude-code-ide-menu))
 
 ;; gptel: Emacs 内で Claude API を直接使う
 (use-package gptel


### PR DESCRIPTION
## 概要

straight.el 経由で導入していた `copilot` と `claude-code-ide` を削除しました。

## 変更内容

- `init.el`
  - straight.el の bootstrap を削除（copilot と claude-code-ide のためだけに使っていたため）
  - `copilot` の `use-package` 設定を削除
  - `claude-code-ide` の `use-package` 設定を削除
  - eat / vterm のコメントから claude-code-ide への言及を除去
  - vterm に `vterm-always-compile-module` を追加（daemon 起動時にモジュールコンパイル確認でブロックしないように）
- `early-init.el`（新規）
  - `package-enable-at-startup nil` を設定し、init.el での明示的な `package-initialize` に初期化を委譲
  - ※ ローカルに残っていた straight.el の残骸 `straight/` ディレクトリは手動削除が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)